### PR TITLE
Fix pip3 install package + update legacy key value format

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,10 +8,10 @@ RUN apk --no-cache add curl; \
 
 # Install CFN Guard
 RUN curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/aws-cloudformation/cloudformation-guard/main/install-guard.sh | sh
-ENV PATH "/root/.guard/bin:${PATH}"
+ENV PATH="/root/.guard/bin:${PATH}"
 
 # Install AWS SusScan
-RUN pip3 install git+https://github.com/awslabs/sustainability-scanner.git@v1.0.1
+RUN pip3 install sustainability-scanner
 
 # Uninstall libs
 RUN apk del git; \


### PR DESCRIPTION
Issue #9 

*Description of changes:*
- Change the pip install package from hardcoded v1.0.1 to the latest version of sustainability-scanner.
- Update legacy key value format to add ~/.guard/bin/ to $PATH
